### PR TITLE
Remove references to 'uno install'

### DIFF
--- a/Samples/BarChart/README.md
+++ b/Samples/BarChart/README.md
@@ -4,13 +4,7 @@ This example shows how we can create bar charts using the premium Fuse.Charting 
 
 ## Preparation
 
-In order to use the library, you have to install it. This is done by running the following command from the commandline:
-
-```
-uno install Fuse.Charting
-```
-
-With that done, you should be all set. Remember to include `Fuse.Charting` package in your unoproj file:
+In order to use the library, you have to include `Fuse.Charting` package in your unoproj file:
 
 ```
 "Packages": [

--- a/Samples/LineGraph/README.md
+++ b/Samples/LineGraph/README.md
@@ -4,13 +4,7 @@ This example shows how you can create simple, but good looking graphs using the 
 
 ## Preparation
 
-In order to use the library, you have to install it. This is done by running the following command from the commandline:
-
-```
-uno install Fuse.Charting
-```
-
-With that done, you should be all set. Remember to include `Fuse.Charting` package in your unoproj file:
+In order to use the library, you have to include `Fuse.Charting` package in your unoproj file:
 
 ```
 "Packages": [

--- a/Samples/PieChart/README.md
+++ b/Samples/PieChart/README.md
@@ -4,13 +4,7 @@ This example shows how you can create simple, but good looking graphs using the 
 
 ## Preparation
 
-In order to use the library, you have to install it. This is done by running the following command from the commandline:
-
-```
-uno install Fuse.Charting
-```
-
-With that done, you should be all set. Remember to include `Fuse.Charting` package in your unoproj file:
+In order to use the library, you have to include `Fuse.Charting` package in your unoproj file:
 
 ```
 "Packages": [


### PR DESCRIPTION
`uno install` will be removed in the next release, and it is no longer necessary to install `Fuse.Charting` to use it.